### PR TITLE
Define top level order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+- [breaking change] define order of block mixins, variables, custom properties, and inline declarations
+
 ## [1.1.0] - 30.01.2018
 
 ### Added

--- a/rules/order.js
+++ b/rules/order.js
@@ -253,5 +253,15 @@ module.exports = {
                 unspecified: 'bottom',
             },
         ],
+        'order/order': [
+            'custom-properties',
+            'dollar-variables',
+            'declarations',
+            {
+                type: 'at-rule',
+                name: 'include',
+                hasBlock: true
+            },
+        ],
     }
 };


### PR DESCRIPTION
Define order of block mixins, variables, custom properties, and inline declarations

There an issue with current putting of block mixins to the very beginning, for example, this code:

```scss
.woot {
  display: block;

  @include media_from__M {
    display: none;
  }
}
```

is invalid now.

This PR defines the order of block mixins as the bottom. As well it adjusts variables, custom properties and any declarations to the very beginning.

![image](https://user-images.githubusercontent.com/2461970/35890105-89a0f484-0b9e-11e8-8b55-81949c379069.png)
