### PR TITLE
Allow Uppercase in modifiers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Changed
+
+- Extend at mixin pattern with modificators
+
 ## [2.0.0] – 07.02.2018
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 
-- Extend at mixin pattern with modificators
+- Allow upper case in modificators for mixins and variables
 
 ## [2.0.0] – 07.02.2018
 

--- a/rules/scss.js
+++ b/rules/scss.js
@@ -11,7 +11,7 @@ module.exports = {
         'scss/dollar-variable-colon-space-after': 'always',
         'scss/dollar-variable-colon-space-before': 'never',
         'scss/dollar-variable-pattern': [
-            '^(([a-z0-9]+([A-Z][a-z0-9])*)*)+(_([a-z0-9]+([A-Z][a-z0-9])*)+){0,2}(__([a-z0-9]+([A-Z][a-z0-9])*)+)?$',
+            '^(([a-z0-9]+([A-Z][a-z0-9])*)*)+(_([a-z0-9]+([A-Z][a-z0-9])*)+){0,2}(__([a-zA-Z0-9]+([A-Z][a-z0-9])*)+)?$',
             {
                 message:
                     'Should be in this format [block_element]_property__modifier!',

--- a/rules/scss.js
+++ b/rules/scss.js
@@ -7,7 +7,7 @@ module.exports = {
         'scss/at-function-pattern': '^[a-z]+([a-zA-Z0-9]+[a-z0-9]+)?$',
         'scss/at-import-no-partial-leading-underscore': true,
         'scss/at-import-partial-extension-blacklist': ['scss'],
-        'scss/at-mixin-pattern': '^[a-z]+([a-zA-Z0-9]+[a-z0-9]+)?$',
+        'scss/at-mixin-pattern': '^[a-z]+([a-zA-Z0-9]+[a-z0-9]+)?(__([A-Z0-9]+([A-Z][a-z0-9])*)+)?$',
         'scss/dollar-variable-colon-space-after': 'always',
         'scss/dollar-variable-colon-space-before': 'never',
         'scss/dollar-variable-pattern': [


### PR DESCRIPTION
Current pattern for variables and mixins doesn't allow us to write something like that

```scss
$myAwesome_size__XXL
```

or

```
@include mediaFrom__S
```

This PR adjusts regular expressions and allows that.