### PR TITLE
Release v2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## [2.1.0] – 01.03.2018
 
 Remove stylelint as peer and update other dependencies to latest versions 
 
@@ -12,7 +12,6 @@ Remove stylelint as peer and update other dependencies to latest versions
 
 ### Fixed
 - at mixin and variables regexp bug
-
 
 ## [2.0.1] – 08.02.2018
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
-Remove stylelint as peer and update other dependecies to latest versions 
+Remove stylelint as peer and update other dependencies to latest versions 
 
 ## [2.0.2] – 08.02.2018
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,17 +4,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+Remove stylelint as peer and update other dependecies to latest versions 
+
 ## [2.0.2] – 08.02.2018
 
 ### Fixed
-
 - at mixin and variables regexp bug
 
 
 ## [2.0.1] – 08.02.2018
 
 ### Changed
-
 - Allow upper case in modificators for mixins and variables
 
 ## [2.0.0] – 07.02.2018
@@ -25,16 +27,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [1.2.0] – 01.02.2018
 
 ### Changed
-
 - [breaking change] `selector-class-pattern` and `scss/dollar-variable-pattern` fixed regex to prevent `__`
 - [breaking change] scss rules are added to global rule set
-
-## [1.1.0] – 30.01.2018
 
 ## [1.1.0] - 30.01.2018
 
 ### Added
-
 - [breaking change] `selector-max-empty-lines` rule
 - [breaking change] `declaration-empty-line-before` rule
 
@@ -42,7 +40,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - [breaking change] `addEmptyLineBefore` function and all mentioning of it
 
 ### Changed
-
 - `rule-empty-line-before` rule
 
 ## [1.0.0] – 29.01.2018
@@ -50,6 +47,5 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 Initial bootstrap from React Shop project
 
 ### Changed (compare with origin)
-
 - decomposed rules
 - `number-leading-zero` rule `never` → `always`

--- a/package-lock.json
+++ b/package-lock.json
@@ -2008,9 +2008,9 @@
             }
         },
         "stylelint-order": {
-            "version": "0.8.0",
-            "resolved": "https://registry.npmjs.org/stylelint-order/-/stylelint-order-0.8.0.tgz",
-            "integrity": "sha512-XwJO7rIAt/hnBJjOsDgEwNSeqw+5jE22da4pVKaePbojM9bGwhOoAWV7Q2BL8caOg81IlTesmYCEf8s0+2Cc5g==",
+            "version": "0.8.1",
+            "resolved": "https://registry.npmjs.org/stylelint-order/-/stylelint-order-0.8.1.tgz",
+            "integrity": "sha512-8mp1P2wnI9XShYXVXDsxVigE2eXnc0C2O4ktbwUvTBwjCP4xZskIbUVxp1evSG3OK4R7hXVNl/2BnJCZkrcc/w==",
             "requires": {
                 "lodash": "4.17.4",
                 "postcss": "6.0.16",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@zattoo/stylelint-config",
-    "version": "2.0.2",
+    "version": "2.1.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,20 +5,19 @@
     "requires": true,
     "dependencies": {
         "ajv": {
-            "version": "5.5.2",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
-            "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+            "version": "6.2.0",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.2.0.tgz",
+            "integrity": "sha1-r6wpW7qgFSRJ5SJ0LkVHwa6TKNI=",
             "requires": {
-                "co": "4.6.0",
-                "fast-deep-equal": "1.0.0",
+                "fast-deep-equal": "1.1.0",
                 "fast-json-stable-stringify": "2.0.0",
                 "json-schema-traverse": "0.3.1"
             }
         },
         "ajv-keywords": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-2.1.1.tgz",
-            "integrity": "sha1-YXmX/F9gV2iUxDX5QNgZ4TW4B2I="
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.1.0.tgz",
+            "integrity": "sha1-rCsnk5xUPpXSwG5/f1wnvkqlQ74="
         },
         "ansi-regex": {
             "version": "2.1.1",
@@ -34,9 +33,9 @@
             }
         },
         "argparse": {
-            "version": "1.0.9",
-            "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
-            "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
+            "version": "1.0.10",
+            "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+            "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
             "requires": {
                 "sprintf-js": "1.0.3"
             }
@@ -88,15 +87,15 @@
             "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0="
         },
         "autoprefixer": {
-            "version": "7.2.5",
-            "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-7.2.5.tgz",
-            "integrity": "sha512-XqHfo8Ht0VU+T5P+eWEVoXza456KJ4l62BPewu3vpNf3LP9s2+zYXkXBznzYby4XeECXgG3N4i+hGvOhXErZmA==",
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-8.0.0.tgz",
+            "integrity": "sha512-XBEqAoESCyGu3daYmWcTC37Dwmjvs0y40UtUO3MMX+Pd/w7jwNFfUKNtxoMFu0u0wcotP+arDpU3JVH54UV79Q==",
             "requires": {
-                "browserslist": "2.11.3",
-                "caniuse-lite": "1.0.30000792",
+                "browserslist": "3.1.1",
+                "caniuse-lite": "1.0.30000810",
                 "normalize-range": "0.1.2",
                 "num2fraction": "1.2.2",
-                "postcss": "6.0.16",
+                "postcss": "6.0.19",
                 "postcss-value-parser": "3.3.0"
             }
         },
@@ -111,9 +110,9 @@
             "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
         },
         "brace-expansion": {
-            "version": "1.1.8",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
-            "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
+            "version": "1.1.11",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+            "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
             "requires": {
                 "balanced-match": "1.0.0",
                 "concat-map": "0.0.1"
@@ -130,12 +129,12 @@
             }
         },
         "browserslist": {
-            "version": "2.11.3",
-            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-2.11.3.tgz",
-            "integrity": "sha512-yWu5cXT7Av6mVwzWc8lMsJMHWn4xyjSuGYi4IozbVTLUOEYPSagUB8kiMDUHA1fS3zjr8nkxkn9jdvug4BBRmA==",
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-3.1.1.tgz",
+            "integrity": "sha512-zHGaPnTt70ywm+glR7uMJFZSl+ADGO67SgD2ae20L+Y3KJUeH4fVa89OkTqKCqAnXFE9mO4LTHBKBqKRlr7VNw==",
             "requires": {
-                "caniuse-lite": "1.0.30000792",
-                "electron-to-chromium": "1.3.31"
+                "caniuse-lite": "1.0.30000810",
+                "electron-to-chromium": "1.3.34"
             }
         },
         "builtin-modules": {
@@ -159,9 +158,9 @@
             }
         },
         "caniuse-lite": {
-            "version": "1.0.30000792",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000792.tgz",
-            "integrity": "sha1-0M6pgfgRjzlhRxr7tDyaHlu/AzI="
+            "version": "1.0.30000810",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000810.tgz",
+            "integrity": "sha512-/0Q00Oie9C72P8zQHtFvzmkrMC3oOFUnMWjCy5F2+BE8lzICm91hQPhh0+XIsAFPKOe2Dh3pKgbRmU3EKxfldA=="
         },
         "ccount": {
             "version": "1.0.2",
@@ -169,23 +168,13 @@
             "integrity": "sha1-U7ai+BW7d7nChx97mnLDol8djok="
         },
         "chalk": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
-            "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.1.tgz",
+            "integrity": "sha512-QUU4ofkDoMIVO7hcx1iPTISs88wsO8jA92RQIm4JAwZvFGGAV2hSAA1NX7oVj2Ej2Q6NDTcRDjPTFrMCRZoJ6g==",
             "requires": {
                 "ansi-styles": "3.2.0",
                 "escape-string-regexp": "1.0.5",
-                "supports-color": "4.5.0"
-            },
-            "dependencies": {
-                "supports-color": {
-                    "version": "4.5.0",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
-                    "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
-                    "requires": {
-                        "has-flag": "2.0.0"
-                    }
-                }
+                "supports-color": "5.2.0"
             }
         },
         "character-entities": {
@@ -222,11 +211,6 @@
                 "is-supported-regexp-flag": "1.0.0"
             }
         },
-        "co": {
-            "version": "4.6.0",
-            "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-            "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
-        },
         "collapse-white-space": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/collapse-white-space/-/collapse-white-space-1.0.3.tgz",
@@ -256,13 +240,13 @@
             "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
         },
         "cosmiconfig": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-3.1.0.tgz",
-            "integrity": "sha512-zedsBhLSbPBms+kE7AH4vHg6JsKDz6epSv2/+5XHs8ILHlgDciSJfSWf8sX9aQ52Jb7KI7VswUTsLpR/G0cr2Q==",
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-4.0.0.tgz",
+            "integrity": "sha512-6e5vDdrXZD+t5v0L8CrurPeybg4Fmf+FCSYxXKYVAqLUtyCSbuyqE059d0kDthTNRzKVjL7QMgNpEUlsoYH3iQ==",
             "requires": {
                 "is-directory": "0.3.1",
                 "js-yaml": "3.10.0",
-                "parse-json": "3.0.0",
+                "parse-json": "4.0.0",
                 "require-from-string": "2.0.1"
             }
         },
@@ -376,9 +360,9 @@
             }
         },
         "domutils": {
-            "version": "1.6.2",
-            "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.6.2.tgz",
-            "integrity": "sha1-GVjMC0yUJuntNn+xyOhUiRsPo/8=",
+            "version": "1.7.0",
+            "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.7.0.tgz",
+            "integrity": "sha512-Lgd2XcJ/NjEw+7tFvfKxOzCYKZsdct5lczQ2ZaQY8Djz7pfAD3Gbp8ySJWtreII/vDlMVmxwa6pHmdxIYgttDg==",
             "requires": {
                 "dom-serializer": "0.1.0",
                 "domelementtype": "1.3.0"
@@ -393,9 +377,9 @@
             }
         },
         "electron-to-chromium": {
-            "version": "1.3.31",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.31.tgz",
-            "integrity": "sha512-XE4CLbswkZgZFn34cKFy1xaX+F5LHxeDLjY1+rsK9asDzknhbrd9g/n/01/acbU25KTsUSiLKwvlLyA+6XLUOA=="
+            "version": "1.3.34",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.34.tgz",
+            "integrity": "sha1-2TSY9AORuwwWpgPYJBuZUUBBV+0="
         },
         "entities": {
             "version": "1.1.1",
@@ -458,9 +442,9 @@
             }
         },
         "fast-deep-equal": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz",
-            "integrity": "sha1-liVqO8l1WV6zbYLpkp0GDYk0Of8="
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
+            "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ="
         },
         "fast-json-stable-stringify": {
             "version": "2.0.0",
@@ -612,9 +596,9 @@
             }
         },
         "has-flag": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
-            "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE="
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+            "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
         },
         "hosted-git-info": {
             "version": "2.5.0",
@@ -633,10 +617,10 @@
             "requires": {
                 "domelementtype": "1.3.0",
                 "domhandler": "2.4.1",
-                "domutils": "1.6.2",
+                "domutils": "1.7.0",
                 "entities": "1.1.1",
                 "inherits": "2.0.3",
-                "readable-stream": "2.3.3"
+                "readable-stream": "2.3.4"
             }
         },
         "ignore": {
@@ -853,7 +837,7 @@
             "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.10.0.tgz",
             "integrity": "sha512-O2v52ffjLa9VeM43J4XocZE//WT9N0IiwDa3KSHH7Tu8CtH+1qM8SIZvnsTh6v+4yFy5KUY3BHUVwjpfAWsjIA==",
             "requires": {
-                "argparse": "1.0.9",
+                "argparse": "1.0.10",
                 "esprima": "4.0.0"
             }
         },
@@ -876,9 +860,9 @@
             }
         },
         "known-css-properties": {
-            "version": "0.5.0",
-            "resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.5.0.tgz",
-            "integrity": "sha512-LOS0CoS8zcZnB1EjLw4LLqDXw8nvt3AGH5dXLQP3D9O1nLLA+9GC5GnPl5mmF+JiQAtSX4VyZC7KvEtcA4kUtA=="
+            "version": "0.6.1",
+            "resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.6.1.tgz",
+            "integrity": "sha512-nQRpMcHm1cQ6gmztdvLcIvxocznSMqH/y6XtERrWrHaymOYdDGroRqetJvJycxGEr1aakXiigDgn7JnzuXlk6A=="
         },
         "load-json-file": {
             "version": "4.0.0",
@@ -889,17 +873,6 @@
                 "parse-json": "4.0.0",
                 "pify": "3.0.0",
                 "strip-bom": "3.0.0"
-            },
-            "dependencies": {
-                "parse-json": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
-                    "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
-                    "requires": {
-                        "error-ex": "1.3.1",
-                        "json-parse-better-errors": "1.0.1"
-                    }
-                }
             }
         },
         "locate-path": {
@@ -912,16 +885,16 @@
             }
         },
         "lodash": {
-            "version": "4.17.4",
-            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-            "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
+            "version": "4.17.5",
+            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
+            "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw=="
         },
         "log-symbols": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",
             "integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
             "requires": {
-                "chalk": "2.3.0"
+                "chalk": "2.3.1"
             }
         },
         "longest-streak": {
@@ -1015,7 +988,7 @@
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
             "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
             "requires": {
-                "brace-expansion": "1.1.8"
+                "brace-expansion": "1.1.11"
             }
         },
         "minimist": {
@@ -1053,7 +1026,7 @@
                 "hosted-git-info": "2.5.0",
                 "is-builtin-module": "1.0.0",
                 "semver": "5.5.0",
-                "validate-npm-package-license": "3.0.1"
+                "validate-npm-package-license": "3.0.3"
             }
         },
         "normalize-path": {
@@ -1147,11 +1120,12 @@
             }
         },
         "parse-json": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-3.0.0.tgz",
-            "integrity": "sha1-+m9HsY4jgm6tMvJj50TQ4ehH+xM=",
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+            "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
             "requires": {
-                "error-ex": "1.3.1"
+                "error-ex": "1.3.1",
+                "json-parse-better-errors": "1.0.1"
             }
         },
         "path-exists": {
@@ -1196,13 +1170,13 @@
             }
         },
         "postcss": {
-            "version": "6.0.16",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.16.tgz",
-            "integrity": "sha512-m758RWPmSjFH/2MyyG3UOW1fgYbR9rtdzz5UNJnlm7OLtu4B2h9C6gi+bE4qFKghsBRFfZT8NzoQBs6JhLotoA==",
+            "version": "6.0.19",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.19.tgz",
+            "integrity": "sha512-f13HRz0HtVwVaEuW6J6cOUCBLFtymhgyLPV7t4QEk2UD3twRI9IluDcQNdzQdBpiixkXj2OmzejhhTbSbDxNTg==",
             "requires": {
-                "chalk": "2.3.0",
+                "chalk": "2.3.1",
                 "source-map": "0.6.1",
-                "supports-color": "5.1.0"
+                "supports-color": "5.2.0"
             }
         },
         "postcss-html": {
@@ -1288,10 +1262,10 @@
             "resolved": "https://registry.npmjs.org/postcss-reporter/-/postcss-reporter-5.0.0.tgz",
             "integrity": "sha512-rBkDbaHAu5uywbCR2XE8a25tats3xSOsGNx6mppK6Q9kSFGKc/FyAzfci+fWM2l+K402p1D0pNcfDGxeje5IKg==",
             "requires": {
-                "chalk": "2.3.0",
-                "lodash": "4.17.4",
+                "chalk": "2.3.1",
+                "lodash": "4.17.5",
                 "log-symbols": "2.2.0",
-                "postcss": "6.0.16"
+                "postcss": "6.0.19"
             }
         },
         "postcss-resolve-nested-selector": {
@@ -1304,24 +1278,24 @@
             "resolved": "https://registry.npmjs.org/postcss-safe-parser/-/postcss-safe-parser-3.0.1.tgz",
             "integrity": "sha1-t1Pv9sfArqXoN1++TN6L+QY/8UI=",
             "requires": {
-                "postcss": "6.0.16"
+                "postcss": "6.0.19"
             }
         },
         "postcss-sass": {
-            "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/postcss-sass/-/postcss-sass-0.2.0.tgz",
-            "integrity": "sha512-cUmYzkP747fPCQE6d+CH2l1L4VSyIlAzZsok3HPjb5Gzsq3jE+VjpAdGlPsnQ310WKWI42sw+ar0UNN59/f3hg==",
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/postcss-sass/-/postcss-sass-0.3.0.tgz",
+            "integrity": "sha512-nZJEFS2bT007CmzMjlZfZwcZKpSJ/JeFiVEdgrgvGZtAnORU+5BvN0cioNuDAVxwXHXp3hksCJzbZYPWkuw41Q==",
             "requires": {
                 "gonzales-pe": "4.2.3",
-                "postcss": "6.0.16"
+                "postcss": "6.0.19"
             }
         },
         "postcss-scss": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/postcss-scss/-/postcss-scss-1.0.3.tgz",
-            "integrity": "sha512-N2ZPDOV5PGEGVwdiB7b1QppxKkmkHodNWkemja7PV+/mHqbUlA6ZcYRreden5Ag5nwBBX8/aRE7lfg1xjdszyg==",
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/postcss-scss/-/postcss-scss-1.0.4.tgz",
+            "integrity": "sha512-IFj42Hz2cBHHFvZTqkJqU08JCCM/MZU5/uNkTUZBaBFP2d4C5unw4HyCL52RfCwJb6KoVUD3eoepxMh1dfBFCQ==",
             "requires": {
-                "postcss": "6.0.16"
+                "postcss": "6.0.19"
             }
         },
         "postcss-selector-parser": {
@@ -1339,8 +1313,8 @@
             "resolved": "https://registry.npmjs.org/postcss-sorting/-/postcss-sorting-3.1.0.tgz",
             "integrity": "sha512-YCPTcJwGIInF1LpMD1lIYvMHTGUL4s97o/OraA6eKvoauhhk6vjwOWDDjm6uRKqug/kyDPMKEzmYZ6FtW6RDgw==",
             "requires": {
-                "lodash": "4.17.4",
-                "postcss": "6.0.16"
+                "lodash": "4.17.5",
+                "postcss": "6.0.19"
             }
         },
         "postcss-value-parser": {
@@ -1354,9 +1328,9 @@
             "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks="
         },
         "process-nextick-args": {
-            "version": "1.0.7",
-            "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-            "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+            "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
         },
         "quick-lru": {
             "version": "1.1.0",
@@ -1420,14 +1394,14 @@
             }
         },
         "readable-stream": {
-            "version": "2.3.3",
-            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
-            "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
+            "version": "2.3.4",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.4.tgz",
+            "integrity": "sha512-vuYxeWYM+fde14+rajzqgeohAI7YoJcHE7kXDAc4Nk0EbuKnJfqtY9YtRkLo/tqkuF7MsBQRhPnPeyjYITp3ZQ==",
             "requires": {
                 "core-util-is": "1.0.2",
                 "inherits": "2.0.3",
                 "isarray": "1.0.0",
-                "process-nextick-args": "1.0.7",
+                "process-nextick-args": "2.0.0",
                 "safe-buffer": "5.1.1",
                 "string_decoder": "1.0.3",
                 "util-deprecate": "1.0.2"
@@ -1575,22 +1549,32 @@
             "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
         },
         "spdx-correct": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
-            "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.0.0.tgz",
+            "integrity": "sha512-N19o9z5cEyc8yQQPukRCZ9EUmb4HUpnrmaL/fxS2pBo2jbfcFRVuFZ/oFC+vZz0MNNk0h80iMn5/S6qGZOL5+g==",
             "requires": {
-                "spdx-license-ids": "1.2.2"
+                "spdx-expression-parse": "3.0.0",
+                "spdx-license-ids": "3.0.0"
             }
         },
+        "spdx-exceptions": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.1.0.tgz",
+            "integrity": "sha512-4K1NsmrlCU1JJgUrtgEeTVyfx8VaYea9J9LvARxhbHtVtohPs/gFGG5yy49beySjlIMhhXZ4QqujIZEfS4l6Cg=="
+        },
         "spdx-expression-parse": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz",
-            "integrity": "sha1-m98vIOH0DtRH++JzJmGR/O1RYmw="
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
+            "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
+            "requires": {
+                "spdx-exceptions": "2.1.0",
+                "spdx-license-ids": "3.0.0"
+            }
         },
         "spdx-license-ids": {
-            "version": "1.2.2",
-            "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
-            "integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc="
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.0.tgz",
+            "integrity": "sha512-2+EPwgbnmOIl8HjGBXXMd9NAu02vLjOO1nWw4kmeRDFyHn+M/ETfHxQUK0oXg8ctgVnl9t3rosNVsZ1jG61nDA=="
         },
         "specificity": {
             "version": "0.3.2",
@@ -1674,14 +1658,14 @@
             "integrity": "sha1-eVjHk+R+MuB9K1yv5cC/jhLneQI="
         },
         "stylelint": {
-            "version": "8.4.0",
-            "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-8.4.0.tgz",
-            "integrity": "sha512-56hPH5mTFnk8LzlEuTWq0epa34fHuS54UFYQidBOFt563RJBNi1nz1F2HK2MoT1X1waq47milvRsRahFCCJs/Q==",
+            "version": "9.1.1",
+            "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-9.1.1.tgz",
+            "integrity": "sha512-BYhAUd8ZiMcRx9cgVOWhckiixK93zXfYB2IwBZxcH+sFE7fp2nvs6xbx97P/wa3obhRLVukrIOH/1BHiukcuOQ==",
             "requires": {
-                "autoprefixer": "7.2.5",
+                "autoprefixer": "8.0.0",
                 "balanced-match": "1.0.0",
-                "chalk": "2.3.0",
-                "cosmiconfig": "3.1.0",
+                "chalk": "2.3.1",
+                "cosmiconfig": "4.0.0",
                 "debug": "3.1.0",
                 "execall": "1.0.0",
                 "file-entry-cache": "2.0.0",
@@ -1691,50 +1675,51 @@
                 "html-tags": "2.0.0",
                 "ignore": "3.3.7",
                 "imurmurhash": "0.1.4",
-                "known-css-properties": "0.5.0",
-                "lodash": "4.17.4",
+                "known-css-properties": "0.6.1",
+                "lodash": "4.17.5",
                 "log-symbols": "2.2.0",
                 "mathml-tag-names": "2.0.1",
                 "meow": "4.0.0",
                 "micromatch": "2.3.11",
                 "normalize-selector": "0.2.0",
                 "pify": "3.0.0",
-                "postcss": "6.0.16",
+                "postcss": "6.0.19",
                 "postcss-html": "0.12.0",
                 "postcss-less": "1.1.3",
                 "postcss-media-query-parser": "0.2.3",
                 "postcss-reporter": "5.0.0",
                 "postcss-resolve-nested-selector": "0.1.1",
                 "postcss-safe-parser": "3.0.1",
-                "postcss-sass": "0.2.0",
-                "postcss-scss": "1.0.3",
+                "postcss-sass": "0.3.0",
+                "postcss-scss": "1.0.4",
                 "postcss-selector-parser": "3.1.1",
                 "postcss-value-parser": "3.3.0",
                 "resolve-from": "4.0.0",
+                "signal-exit": "3.0.2",
                 "specificity": "0.3.2",
                 "string-width": "2.1.1",
                 "style-search": "0.1.0",
                 "sugarss": "1.0.1",
                 "svg-tags": "1.0.0",
-                "table": "4.0.2"
+                "table": "4.0.3"
             }
         },
         "stylelint-order": {
-            "version": "0.8.0",
-            "resolved": "https://registry.npmjs.org/stylelint-order/-/stylelint-order-0.8.0.tgz",
-            "integrity": "sha512-XwJO7rIAt/hnBJjOsDgEwNSeqw+5jE22da4pVKaePbojM9bGwhOoAWV7Q2BL8caOg81IlTesmYCEf8s0+2Cc5g==",
+            "version": "0.8.1",
+            "resolved": "https://registry.npmjs.org/stylelint-order/-/stylelint-order-0.8.1.tgz",
+            "integrity": "sha512-8mp1P2wnI9XShYXVXDsxVigE2eXnc0C2O4ktbwUvTBwjCP4xZskIbUVxp1evSG3OK4R7hXVNl/2BnJCZkrcc/w==",
             "requires": {
-                "lodash": "4.17.4",
-                "postcss": "6.0.16",
+                "lodash": "4.17.5",
+                "postcss": "6.0.19",
                 "postcss-sorting": "3.1.0"
             }
         },
         "stylelint-scss": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/stylelint-scss/-/stylelint-scss-2.3.0.tgz",
-            "integrity": "sha512-gYLw1jma/BUZ9eQ3hsrL/7bddQN2BJ13oSp0A0kOqje4hBrSCrUjf7rmpnK8taRWoU3KASwMo4apWg+YopDK5Q==",
+            "version": "2.4.0",
+            "resolved": "https://registry.npmjs.org/stylelint-scss/-/stylelint-scss-2.4.0.tgz",
+            "integrity": "sha512-jIZuxCVDF9ZXklc1X9dXy63oolyw2UsVZc65eN6qqWE15gBXISYJfU4na3sR6/KLsTWE0ceSp8Z4OvP8q0Q4SQ==",
             "requires": {
-                "lodash": "4.17.4",
+                "lodash": "4.17.5",
                 "postcss-media-query-parser": "0.2.3",
                 "postcss-resolve-nested-selector": "0.1.1",
                 "postcss-selector-parser": "3.1.1",
@@ -1746,15 +1731,15 @@
             "resolved": "https://registry.npmjs.org/sugarss/-/sugarss-1.0.1.tgz",
             "integrity": "sha512-3qgLZytikQQEVn1/FrhY7B68gPUUGY3R1Q1vTiD5xT+Ti1DP/8iZuwFet9ONs5+bmL8pZoDQ6JrQHVgrNlK6mA==",
             "requires": {
-                "postcss": "6.0.16"
+                "postcss": "6.0.19"
             }
         },
         "supports-color": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.1.0.tgz",
-            "integrity": "sha512-Ry0AwkoKjDpVKK4sV4h6o3UJmNRbjYm2uXhwfj3J56lMVdvnUNqzQVRztOOMGQ++w1K/TjNDFvpJk0F/LoeBCQ==",
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.2.0.tgz",
+            "integrity": "sha512-F39vS48la4YvTZUPVeTqsjsFNrvcMwrV3RLZINsmHo+7djCvuUzSIeXOnZ5hmjef4bajL1dNccN+tg5XAliO5Q==",
             "requires": {
-                "has-flag": "2.0.0"
+                "has-flag": "3.0.0"
             }
         },
         "svg-tags": {
@@ -1763,14 +1748,14 @@
             "integrity": "sha1-WPcc7jvVGbWdSyqEO2x95krAR2Q="
         },
         "table": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/table/-/table-4.0.2.tgz",
-            "integrity": "sha512-UUkEAPdSGxtRpiV9ozJ5cMTtYiqz7Ni1OGqLXRCynrvzdtR1p+cfOWe2RJLwvUG8hNanaSRjecIqwOjqeatDsA==",
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/table/-/table-4.0.3.tgz",
+            "integrity": "sha512-S7rnFITmBH1EnyKcvxBh1LjYeQMmnZtCXSEbHcH6S0NoKit24ZuFO/T1vDcLdYsLQkM188PVVhQmzKIuThNkKg==",
             "requires": {
-                "ajv": "5.5.2",
-                "ajv-keywords": "2.1.1",
-                "chalk": "2.3.0",
-                "lodash": "4.17.4",
+                "ajv": "6.2.0",
+                "ajv-keywords": "3.1.0",
+                "chalk": "2.3.1",
+                "lodash": "4.17.5",
                 "slice-ansi": "1.0.0",
                 "string-width": "2.1.1"
             }
@@ -1871,12 +1856,12 @@
             "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
         },
         "validate-npm-package-license": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
-            "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.3.tgz",
+            "integrity": "sha512-63ZOUnL4SIXj4L0NixR3L1lcjO38crAbgrTpl28t8jjrfuiOBL5Iygm+60qPs/KsZGzPNg6Smnc/oY16QTjF0g==",
             "requires": {
-                "spdx-correct": "1.0.2",
-                "spdx-expression-parse": "1.0.4"
+                "spdx-correct": "3.0.0",
+                "spdx-expression-parse": "3.0.0"
             }
         },
         "vfile": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2018,9 +2018,9 @@
             }
         },
         "stylelint-scss": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/stylelint-scss/-/stylelint-scss-2.3.0.tgz",
-            "integrity": "sha512-gYLw1jma/BUZ9eQ3hsrL/7bddQN2BJ13oSp0A0kOqje4hBrSCrUjf7rmpnK8taRWoU3KASwMo4apWg+YopDK5Q==",
+            "version": "2.4.0",
+            "resolved": "https://registry.npmjs.org/stylelint-scss/-/stylelint-scss-2.4.0.tgz",
+            "integrity": "sha512-jIZuxCVDF9ZXklc1X9dXy63oolyw2UsVZc65eN6qqWE15gBXISYJfU4na3sR6/KLsTWE0ceSp8Z4OvP8q0Q4SQ==",
             "requires": {
                 "lodash": "4.17.4",
                 "postcss-media-query-parser": "0.2.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,11 +20,6 @@
             "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-2.1.1.tgz",
             "integrity": "sha1-YXmX/F9gV2iUxDX5QNgZ4TW4B2I="
         },
-        "ansi-escapes": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
-            "integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4="
-        },
         "ansi-regex": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
@@ -92,29 +87,51 @@
             "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
             "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0="
         },
-        "babel-polyfill": {
-            "version": "6.23.0",
-            "resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.23.0.tgz",
-            "integrity": "sha1-g2TKYt+Or7gwSZ9pkXdGbDsDSZ0=",
+        "autoprefixer": {
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-8.0.0.tgz",
+            "integrity": "sha512-XBEqAoESCyGu3daYmWcTC37Dwmjvs0y40UtUO3MMX+Pd/w7jwNFfUKNtxoMFu0u0wcotP+arDpU3JVH54UV79Q==",
             "requires": {
-                "babel-runtime": "6.26.0",
-                "core-js": "2.5.3",
-                "regenerator-runtime": "0.10.5"
-            }
-        },
-        "babel-runtime": {
-            "version": "6.26.0",
-            "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
-            "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
-            "requires": {
-                "core-js": "2.5.3",
-                "regenerator-runtime": "0.11.1"
+                "browserslist": "3.1.1",
+                "caniuse-lite": "1.0.30000810",
+                "normalize-range": "0.1.2",
+                "num2fraction": "1.2.2",
+                "postcss": "6.0.19",
+                "postcss-value-parser": "3.3.0"
             },
             "dependencies": {
-                "regenerator-runtime": {
-                    "version": "0.11.1",
-                    "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-                    "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
+                "chalk": {
+                    "version": "2.3.1",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.1.tgz",
+                    "integrity": "sha512-QUU4ofkDoMIVO7hcx1iPTISs88wsO8jA92RQIm4JAwZvFGGAV2hSAA1NX7oVj2Ej2Q6NDTcRDjPTFrMCRZoJ6g==",
+                    "requires": {
+                        "ansi-styles": "3.2.0",
+                        "escape-string-regexp": "1.0.5",
+                        "supports-color": "5.2.0"
+                    }
+                },
+                "has-flag": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+                    "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+                },
+                "postcss": {
+                    "version": "6.0.19",
+                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.19.tgz",
+                    "integrity": "sha512-f13HRz0HtVwVaEuW6J6cOUCBLFtymhgyLPV7t4QEk2UD3twRI9IluDcQNdzQdBpiixkXj2OmzejhhTbSbDxNTg==",
+                    "requires": {
+                        "chalk": "2.3.1",
+                        "source-map": "0.6.1",
+                        "supports-color": "5.2.0"
+                    }
+                },
+                "supports-color": {
+                    "version": "5.2.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.2.0.tgz",
+                    "integrity": "sha512-F39vS48la4YvTZUPVeTqsjsFNrvcMwrV3RLZINsmHo+7djCvuUzSIeXOnZ5hmjef4bajL1dNccN+tg5XAliO5Q==",
+                    "requires": {
+                        "has-flag": "3.0.0"
+                    }
                 }
             }
         },
@@ -147,6 +164,15 @@
                 "repeat-element": "1.1.2"
             }
         },
+        "browserslist": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-3.1.1.tgz",
+            "integrity": "sha512-zHGaPnTt70ywm+glR7uMJFZSl+ADGO67SgD2ae20L+Y3KJUeH4fVa89OkTqKCqAnXFE9mO4LTHBKBqKRlr7VNw==",
+            "requires": {
+                "caniuse-lite": "1.0.30000810",
+                "electron-to-chromium": "1.3.33"
+            }
+        },
         "builtin-modules": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
@@ -166,6 +192,11 @@
                 "map-obj": "2.0.0",
                 "quick-lru": "1.1.0"
             }
+        },
+        "caniuse-lite": {
+            "version": "1.0.30000810",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000810.tgz",
+            "integrity": "sha512-/0Q00Oie9C72P8zQHtFvzmkrMC3oOFUnMWjCy5F2+BE8lzICm91hQPhh0+XIsAFPKOe2Dh3pKgbRmU3EKxfldA=="
         },
         "ccount": {
             "version": "1.0.2",
@@ -212,28 +243,10 @@
             "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-1.1.1.tgz",
             "integrity": "sha1-lCg191Dk7GGjCOYMLvjMEBEgLvw="
         },
-        "chardet": {
-            "version": "0.4.2",
-            "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.4.2.tgz",
-            "integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I="
-        },
         "circular-json": {
             "version": "0.3.3",
             "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
             "integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A=="
-        },
-        "cli-cursor": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
-            "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
-            "requires": {
-                "restore-cursor": "2.0.0"
-            }
-        },
-        "cli-width": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
-            "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk="
         },
         "clone-regexp": {
             "version": "1.0.0",
@@ -272,15 +285,21 @@
             "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
             "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
         },
-        "core-js": {
-            "version": "2.5.3",
-            "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.3.tgz",
-            "integrity": "sha1-isw4NFgk8W2DZbfJtCWRaOjtYD4="
-        },
         "core-util-is": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
             "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+        },
+        "cosmiconfig": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-4.0.0.tgz",
+            "integrity": "sha512-6e5vDdrXZD+t5v0L8CrurPeybg4Fmf+FCSYxXKYVAqLUtyCSbuyqE059d0kDthTNRzKVjL7QMgNpEUlsoYH3iQ==",
+            "requires": {
+                "is-directory": "0.3.1",
+                "js-yaml": "3.10.0",
+                "parse-json": "4.0.0",
+                "require-from-string": "2.0.1"
+            }
         },
         "currently-unhandled": {
             "version": "0.4.1",
@@ -408,13 +427,10 @@
                 "is-obj": "1.0.1"
             }
         },
-        "encoding": {
-            "version": "0.1.12",
-            "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
-            "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
-            "requires": {
-                "iconv-lite": "0.4.19"
-            }
+        "electron-to-chromium": {
+            "version": "1.3.33",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.33.tgz",
+            "integrity": "sha1-vwBwPWKnxlI4E2V4w1LWxcBCpUU="
         },
         "entities": {
             "version": "1.1.1",
@@ -468,16 +484,6 @@
             "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
             "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
         },
-        "external-editor": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.1.0.tgz",
-            "integrity": "sha512-E44iT5QVOUJBKij4IIV3uvxuNlbKS38Tw1HiupxEIHPv9qtC2PrDYohbXV5U+1jnfIXttny8gUhj+oZvflFlzA==",
-            "requires": {
-                "chardet": "0.4.2",
-                "iconv-lite": "0.4.19",
-                "tmp": "0.0.33"
-            }
-        },
         "extglob": {
             "version": "0.3.2",
             "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
@@ -495,14 +501,6 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
             "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
-        },
-        "figures": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
-            "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
-            "requires": {
-                "escape-string-regexp": "1.0.5"
-            }
         },
         "file-entry-cache": {
             "version": "2.0.0",
@@ -676,11 +674,6 @@
                 "readable-stream": "2.3.3"
             }
         },
-        "iconv-lite": {
-            "version": "0.4.19",
-            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
-            "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ=="
-        },
         "ignore": {
             "version": "3.3.7",
             "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.7.tgz",
@@ -714,50 +707,6 @@
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
             "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
-        },
-        "inquirer": {
-            "version": "3.0.6",
-            "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.0.6.tgz",
-            "integrity": "sha1-4EqqnQW3o8ubD0B9BDdfBEcZA0c=",
-            "requires": {
-                "ansi-escapes": "1.4.0",
-                "chalk": "1.1.3",
-                "cli-cursor": "2.1.0",
-                "cli-width": "2.2.0",
-                "external-editor": "2.1.0",
-                "figures": "2.0.0",
-                "lodash": "4.17.4",
-                "mute-stream": "0.0.7",
-                "run-async": "2.3.0",
-                "rx": "4.1.0",
-                "string-width": "2.1.1",
-                "strip-ansi": "3.0.1",
-                "through": "2.3.8"
-            },
-            "dependencies": {
-                "ansi-styles": {
-                    "version": "2.2.1",
-                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-                    "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
-                },
-                "chalk": {
-                    "version": "1.1.3",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-                    "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-                    "requires": {
-                        "ansi-styles": "2.2.1",
-                        "escape-string-regexp": "1.0.5",
-                        "has-ansi": "2.0.0",
-                        "strip-ansi": "3.0.1",
-                        "supports-color": "2.0.0"
-                    }
-                },
-                "supports-color": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-                    "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
-                }
-            }
         },
         "is-alphabetical": {
             "version": "1.0.1",
@@ -896,20 +845,10 @@
             "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
             "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU="
         },
-        "is-promise": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
-            "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o="
-        },
         "is-regexp": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-1.0.0.tgz",
             "integrity": "sha1-/S2INUXEa6xaYz57mgnof6LLUGk="
-        },
-        "is-stream": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-            "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
         },
         "is-supported-regexp-flag": {
             "version": "1.0.0",
@@ -970,6 +909,11 @@
             "requires": {
                 "is-buffer": "1.1.6"
             }
+        },
+        "known-css-properties": {
+            "version": "0.6.1",
+            "resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.6.1.tgz",
+            "integrity": "sha512-nQRpMcHm1cQ6gmztdvLcIvxocznSMqH/y6XtERrWrHaymOYdDGroRqetJvJycxGEr1aakXiigDgn7JnzuXlk6A=="
         },
         "load-json-file": {
             "version": "4.0.0",
@@ -1101,11 +1045,6 @@
                 "regex-cache": "0.4.4"
             }
         },
-        "mimic-fn": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
-            "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ=="
-        },
         "minimatch": {
             "version": "3.0.4",
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
@@ -1140,20 +1079,6 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
             "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-        },
-        "mute-stream": {
-            "version": "0.0.7",
-            "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
-            "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s="
-        },
-        "node-fetch": {
-            "version": "1.6.3",
-            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.6.3.tgz",
-            "integrity": "sha1-3CNO3WSJmC1Y6PDbT2lQKavNjAQ=",
-            "requires": {
-                "encoding": "0.1.12",
-                "is-stream": "1.1.0"
-            }
         },
         "normalize-package-data": {
             "version": "2.4.0",
@@ -1211,70 +1136,6 @@
                 "wrappy": "1.0.2"
             }
         },
-        "onetime": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
-            "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
-            "requires": {
-                "mimic-fn": "1.2.0"
-            }
-        },
-        "opencollective": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/opencollective/-/opencollective-1.0.3.tgz",
-            "integrity": "sha1-ruY3K8KBRFg2kMPKja7PwSDdDvE=",
-            "requires": {
-                "babel-polyfill": "6.23.0",
-                "chalk": "1.1.3",
-                "inquirer": "3.0.6",
-                "minimist": "1.2.0",
-                "node-fetch": "1.6.3",
-                "opn": "4.0.2"
-            },
-            "dependencies": {
-                "ansi-styles": {
-                    "version": "2.2.1",
-                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-                    "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
-                },
-                "chalk": {
-                    "version": "1.1.3",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-                    "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-                    "requires": {
-                        "ansi-styles": "2.2.1",
-                        "escape-string-regexp": "1.0.5",
-                        "has-ansi": "2.0.0",
-                        "strip-ansi": "3.0.1",
-                        "supports-color": "2.0.0"
-                    }
-                },
-                "minimist": {
-                    "version": "1.2.0",
-                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-                    "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
-                },
-                "supports-color": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-                    "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
-                }
-            }
-        },
-        "opn": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/opn/-/opn-4.0.2.tgz",
-            "integrity": "sha1-erwi5kTf9jsKltWrfyeQwPAavJU=",
-            "requires": {
-                "object-assign": "4.1.1",
-                "pinkie-promise": "2.0.1"
-            }
-        },
-        "os-tmpdir": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-            "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
-        },
         "p-limit": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.2.0.tgz",
@@ -1318,6 +1179,15 @@
                 "is-dotfile": "1.0.3",
                 "is-extglob": "1.0.0",
                 "is-glob": "2.0.1"
+            }
+        },
+        "parse-json": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+            "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+            "requires": {
+                "error-ex": "1.3.1",
+                "json-parse-better-errors": "1.0.1"
             }
         },
         "path-exists": {
@@ -1473,6 +1343,15 @@
                 "postcss": "6.0.16"
             }
         },
+        "postcss-sass": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/postcss-sass/-/postcss-sass-0.3.0.tgz",
+            "integrity": "sha512-nZJEFS2bT007CmzMjlZfZwcZKpSJ/JeFiVEdgrgvGZtAnORU+5BvN0cioNuDAVxwXHXp3hksCJzbZYPWkuw41Q==",
+            "requires": {
+                "gonzales-pe": "4.2.3",
+                "postcss": "6.0.16"
+            }
+        },
         "postcss-scss": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/postcss-scss/-/postcss-scss-1.0.3.tgz",
@@ -1599,11 +1478,6 @@
                 "strip-indent": "2.0.0"
             }
         },
-        "regenerator-runtime": {
-            "version": "0.10.5",
-            "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
-            "integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg="
-        },
         "regex-cache": {
             "version": "0.4.4",
             "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
@@ -1695,15 +1569,6 @@
             "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
             "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="
         },
-        "restore-cursor": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
-            "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
-            "requires": {
-                "onetime": "2.0.1",
-                "signal-exit": "3.0.2"
-            }
-        },
         "rimraf": {
             "version": "2.6.2",
             "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
@@ -1711,19 +1576,6 @@
             "requires": {
                 "glob": "7.1.2"
             }
-        },
-        "run-async": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
-            "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
-            "requires": {
-                "is-promise": "2.1.0"
-            }
-        },
-        "rx": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/rx/-/rx-4.1.0.tgz",
-            "integrity": "sha1-pfE/957zt0D+MKqAP7CfmIBdR4I="
         },
         "safe-buffer": {
             "version": "5.1.1",
@@ -1858,9 +1710,9 @@
             "integrity": "sha1-eVjHk+R+MuB9K1yv5cC/jhLneQI="
         },
         "stylelint": {
-            "version": "9.0.0",
-            "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-9.0.0.tgz",
-            "integrity": "sha512-SWQtdT3RBJSw+8xIltBrJfaYLIqFZgraHAhzbyKp/lyB+EpbqfD7txiEUeosVOH6SD1MOfhFWKgRrueymljFsg==",
+            "version": "9.1.1",
+            "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-9.1.1.tgz",
+            "integrity": "sha512-BYhAUd8ZiMcRx9cgVOWhckiixK93zXfYB2IwBZxcH+sFE7fp2nvs6xbx97P/wa3obhRLVukrIOH/1BHiukcuOQ==",
             "requires": {
                 "autoprefixer": "8.0.0",
                 "balanced-match": "1.0.0",
@@ -1882,7 +1734,6 @@
                 "meow": "4.0.0",
                 "micromatch": "2.3.11",
                 "normalize-selector": "0.2.0",
-                "opencollective": "1.0.3",
                 "pify": "3.0.0",
                 "postcss": "6.0.16",
                 "postcss-html": "0.12.0",
@@ -1896,115 +1747,13 @@
                 "postcss-selector-parser": "3.1.1",
                 "postcss-value-parser": "3.3.0",
                 "resolve-from": "4.0.0",
+                "signal-exit": "3.0.2",
                 "specificity": "0.3.2",
                 "string-width": "2.1.1",
                 "style-search": "0.1.0",
                 "sugarss": "1.0.1",
                 "svg-tags": "1.0.0",
                 "table": "4.0.2"
-            },
-            "dependencies": {
-                "autoprefixer": {
-                    "version": "8.0.0",
-                    "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-8.0.0.tgz",
-                    "integrity": "sha512-XBEqAoESCyGu3daYmWcTC37Dwmjvs0y40UtUO3MMX+Pd/w7jwNFfUKNtxoMFu0u0wcotP+arDpU3JVH54UV79Q==",
-                    "requires": {
-                        "browserslist": "3.1.1",
-                        "caniuse-lite": "1.0.30000809",
-                        "normalize-range": "0.1.2",
-                        "num2fraction": "1.2.2",
-                        "postcss": "6.0.19",
-                        "postcss-value-parser": "3.3.0"
-                    },
-                    "dependencies": {
-                        "chalk": {
-                            "version": "2.3.1",
-                            "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.1.tgz",
-                            "integrity": "sha512-QUU4ofkDoMIVO7hcx1iPTISs88wsO8jA92RQIm4JAwZvFGGAV2hSAA1NX7oVj2Ej2Q6NDTcRDjPTFrMCRZoJ6g==",
-                            "requires": {
-                                "ansi-styles": "3.2.0",
-                                "escape-string-regexp": "1.0.5",
-                                "supports-color": "5.2.0"
-                            }
-                        },
-                        "postcss": {
-                            "version": "6.0.19",
-                            "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.19.tgz",
-                            "integrity": "sha512-f13HRz0HtVwVaEuW6J6cOUCBLFtymhgyLPV7t4QEk2UD3twRI9IluDcQNdzQdBpiixkXj2OmzejhhTbSbDxNTg==",
-                            "requires": {
-                                "chalk": "2.3.1",
-                                "source-map": "0.6.1",
-                                "supports-color": "5.2.0"
-                            }
-                        }
-                    }
-                },
-                "browserslist": {
-                    "version": "3.1.1",
-                    "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-3.1.1.tgz",
-                    "integrity": "sha512-zHGaPnTt70ywm+glR7uMJFZSl+ADGO67SgD2ae20L+Y3KJUeH4fVa89OkTqKCqAnXFE9mO4LTHBKBqKRlr7VNw==",
-                    "requires": {
-                        "caniuse-lite": "1.0.30000809",
-                        "electron-to-chromium": "1.3.33"
-                    }
-                },
-                "caniuse-lite": {
-                    "version": "1.0.30000809",
-                    "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000809.tgz",
-                    "integrity": "sha512-tLn4flj2upmMsko3larTkQh21Vp9pylnNPUOhw5+mubL+67U5Fpm4UG5AutzGBc+gBIPSsPFHDynsiMWp5m46g=="
-                },
-                "cosmiconfig": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-4.0.0.tgz",
-                    "integrity": "sha512-6e5vDdrXZD+t5v0L8CrurPeybg4Fmf+FCSYxXKYVAqLUtyCSbuyqE059d0kDthTNRzKVjL7QMgNpEUlsoYH3iQ==",
-                    "requires": {
-                        "is-directory": "0.3.1",
-                        "js-yaml": "3.10.0",
-                        "parse-json": "4.0.0",
-                        "require-from-string": "2.0.1"
-                    }
-                },
-                "electron-to-chromium": {
-                    "version": "1.3.33",
-                    "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.33.tgz",
-                    "integrity": "sha1-vwBwPWKnxlI4E2V4w1LWxcBCpUU="
-                },
-                "has-flag": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-                    "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
-                },
-                "known-css-properties": {
-                    "version": "0.6.1",
-                    "resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.6.1.tgz",
-                    "integrity": "sha512-nQRpMcHm1cQ6gmztdvLcIvxocznSMqH/y6XtERrWrHaymOYdDGroRqetJvJycxGEr1aakXiigDgn7JnzuXlk6A=="
-                },
-                "parse-json": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
-                    "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
-                    "requires": {
-                        "error-ex": "1.3.1",
-                        "json-parse-better-errors": "1.0.1"
-                    }
-                },
-                "postcss-sass": {
-                    "version": "0.3.0",
-                    "resolved": "https://registry.npmjs.org/postcss-sass/-/postcss-sass-0.3.0.tgz",
-                    "integrity": "sha512-nZJEFS2bT007CmzMjlZfZwcZKpSJ/JeFiVEdgrgvGZtAnORU+5BvN0cioNuDAVxwXHXp3hksCJzbZYPWkuw41Q==",
-                    "requires": {
-                        "gonzales-pe": "4.2.3",
-                        "postcss": "6.0.16"
-                    }
-                },
-                "supports-color": {
-                    "version": "5.2.0",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.2.0.tgz",
-                    "integrity": "sha512-F39vS48la4YvTZUPVeTqsjsFNrvcMwrV3RLZINsmHo+7djCvuUzSIeXOnZ5hmjef4bajL1dNccN+tg5XAliO5Q==",
-                    "requires": {
-                        "has-flag": "3.0.0"
-                    }
-                }
             }
         },
         "stylelint-order": {
@@ -2061,19 +1810,6 @@
                 "lodash": "4.17.4",
                 "slice-ansi": "1.0.0",
                 "string-width": "2.1.1"
-            }
-        },
-        "through": {
-            "version": "2.3.8",
-            "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-            "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
-        },
-        "tmp": {
-            "version": "0.0.33",
-            "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-            "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
-            "requires": {
-                "os-tmpdir": "1.0.2"
             }
         },
         "trim": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,11 @@
             "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-2.1.1.tgz",
             "integrity": "sha1-YXmX/F9gV2iUxDX5QNgZ4TW4B2I="
         },
+        "ansi-escapes": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
+            "integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4="
+        },
         "ansi-regex": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
@@ -87,17 +92,30 @@
             "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
             "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0="
         },
-        "autoprefixer": {
-            "version": "7.2.5",
-            "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-7.2.5.tgz",
-            "integrity": "sha512-XqHfo8Ht0VU+T5P+eWEVoXza456KJ4l62BPewu3vpNf3LP9s2+zYXkXBznzYby4XeECXgG3N4i+hGvOhXErZmA==",
+        "babel-polyfill": {
+            "version": "6.23.0",
+            "resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.23.0.tgz",
+            "integrity": "sha1-g2TKYt+Or7gwSZ9pkXdGbDsDSZ0=",
             "requires": {
-                "browserslist": "2.11.3",
-                "caniuse-lite": "1.0.30000792",
-                "normalize-range": "0.1.2",
-                "num2fraction": "1.2.2",
-                "postcss": "6.0.16",
-                "postcss-value-parser": "3.3.0"
+                "babel-runtime": "6.26.0",
+                "core-js": "2.5.3",
+                "regenerator-runtime": "0.10.5"
+            }
+        },
+        "babel-runtime": {
+            "version": "6.26.0",
+            "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
+            "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+            "requires": {
+                "core-js": "2.5.3",
+                "regenerator-runtime": "0.11.1"
+            },
+            "dependencies": {
+                "regenerator-runtime": {
+                    "version": "0.11.1",
+                    "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+                    "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
+                }
             }
         },
         "bail": {
@@ -129,15 +147,6 @@
                 "repeat-element": "1.1.2"
             }
         },
-        "browserslist": {
-            "version": "2.11.3",
-            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-2.11.3.tgz",
-            "integrity": "sha512-yWu5cXT7Av6mVwzWc8lMsJMHWn4xyjSuGYi4IozbVTLUOEYPSagUB8kiMDUHA1fS3zjr8nkxkn9jdvug4BBRmA==",
-            "requires": {
-                "caniuse-lite": "1.0.30000792",
-                "electron-to-chromium": "1.3.31"
-            }
-        },
         "builtin-modules": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
@@ -157,11 +166,6 @@
                 "map-obj": "2.0.0",
                 "quick-lru": "1.1.0"
             }
-        },
-        "caniuse-lite": {
-            "version": "1.0.30000792",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000792.tgz",
-            "integrity": "sha1-0M6pgfgRjzlhRxr7tDyaHlu/AzI="
         },
         "ccount": {
             "version": "1.0.2",
@@ -208,10 +212,28 @@
             "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-1.1.1.tgz",
             "integrity": "sha1-lCg191Dk7GGjCOYMLvjMEBEgLvw="
         },
+        "chardet": {
+            "version": "0.4.2",
+            "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.4.2.tgz",
+            "integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I="
+        },
         "circular-json": {
             "version": "0.3.3",
             "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
             "integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A=="
+        },
+        "cli-cursor": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
+            "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+            "requires": {
+                "restore-cursor": "2.0.0"
+            }
+        },
+        "cli-width": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
+            "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk="
         },
         "clone-regexp": {
             "version": "1.0.0",
@@ -250,21 +272,15 @@
             "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
             "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
         },
+        "core-js": {
+            "version": "2.5.3",
+            "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.3.tgz",
+            "integrity": "sha1-isw4NFgk8W2DZbfJtCWRaOjtYD4="
+        },
         "core-util-is": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
             "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
-        },
-        "cosmiconfig": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-3.1.0.tgz",
-            "integrity": "sha512-zedsBhLSbPBms+kE7AH4vHg6JsKDz6epSv2/+5XHs8ILHlgDciSJfSWf8sX9aQ52Jb7KI7VswUTsLpR/G0cr2Q==",
-            "requires": {
-                "is-directory": "0.3.1",
-                "js-yaml": "3.10.0",
-                "parse-json": "3.0.0",
-                "require-from-string": "2.0.1"
-            }
         },
         "currently-unhandled": {
             "version": "0.4.1",
@@ -392,10 +408,13 @@
                 "is-obj": "1.0.1"
             }
         },
-        "electron-to-chromium": {
-            "version": "1.3.31",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.31.tgz",
-            "integrity": "sha512-XE4CLbswkZgZFn34cKFy1xaX+F5LHxeDLjY1+rsK9asDzknhbrd9g/n/01/acbU25KTsUSiLKwvlLyA+6XLUOA=="
+        "encoding": {
+            "version": "0.1.12",
+            "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
+            "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
+            "requires": {
+                "iconv-lite": "0.4.19"
+            }
         },
         "entities": {
             "version": "1.1.1",
@@ -449,6 +468,16 @@
             "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
             "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
         },
+        "external-editor": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.1.0.tgz",
+            "integrity": "sha512-E44iT5QVOUJBKij4IIV3uvxuNlbKS38Tw1HiupxEIHPv9qtC2PrDYohbXV5U+1jnfIXttny8gUhj+oZvflFlzA==",
+            "requires": {
+                "chardet": "0.4.2",
+                "iconv-lite": "0.4.19",
+                "tmp": "0.0.33"
+            }
+        },
         "extglob": {
             "version": "0.3.2",
             "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
@@ -466,6 +495,14 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
             "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
+        },
+        "figures": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
+            "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
+            "requires": {
+                "escape-string-regexp": "1.0.5"
+            }
         },
         "file-entry-cache": {
             "version": "2.0.0",
@@ -639,6 +676,11 @@
                 "readable-stream": "2.3.3"
             }
         },
+        "iconv-lite": {
+            "version": "0.4.19",
+            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
+            "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ=="
+        },
         "ignore": {
             "version": "3.3.7",
             "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.7.tgz",
@@ -672,6 +714,50 @@
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
             "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+        },
+        "inquirer": {
+            "version": "3.0.6",
+            "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.0.6.tgz",
+            "integrity": "sha1-4EqqnQW3o8ubD0B9BDdfBEcZA0c=",
+            "requires": {
+                "ansi-escapes": "1.4.0",
+                "chalk": "1.1.3",
+                "cli-cursor": "2.1.0",
+                "cli-width": "2.2.0",
+                "external-editor": "2.1.0",
+                "figures": "2.0.0",
+                "lodash": "4.17.4",
+                "mute-stream": "0.0.7",
+                "run-async": "2.3.0",
+                "rx": "4.1.0",
+                "string-width": "2.1.1",
+                "strip-ansi": "3.0.1",
+                "through": "2.3.8"
+            },
+            "dependencies": {
+                "ansi-styles": {
+                    "version": "2.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+                    "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+                },
+                "chalk": {
+                    "version": "1.1.3",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+                    "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+                    "requires": {
+                        "ansi-styles": "2.2.1",
+                        "escape-string-regexp": "1.0.5",
+                        "has-ansi": "2.0.0",
+                        "strip-ansi": "3.0.1",
+                        "supports-color": "2.0.0"
+                    }
+                },
+                "supports-color": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+                    "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+                }
+            }
         },
         "is-alphabetical": {
             "version": "1.0.1",
@@ -810,10 +896,20 @@
             "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
             "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU="
         },
+        "is-promise": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
+            "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o="
+        },
         "is-regexp": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-1.0.0.tgz",
             "integrity": "sha1-/S2INUXEa6xaYz57mgnof6LLUGk="
+        },
+        "is-stream": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+            "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
         },
         "is-supported-regexp-flag": {
             "version": "1.0.0",
@@ -874,11 +970,6 @@
             "requires": {
                 "is-buffer": "1.1.6"
             }
-        },
-        "known-css-properties": {
-            "version": "0.5.0",
-            "resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.5.0.tgz",
-            "integrity": "sha512-LOS0CoS8zcZnB1EjLw4LLqDXw8nvt3AGH5dXLQP3D9O1nLLA+9GC5GnPl5mmF+JiQAtSX4VyZC7KvEtcA4kUtA=="
         },
         "load-json-file": {
             "version": "4.0.0",
@@ -1010,6 +1101,11 @@
                 "regex-cache": "0.4.4"
             }
         },
+        "mimic-fn": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
+            "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ=="
+        },
         "minimatch": {
             "version": "3.0.4",
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
@@ -1044,6 +1140,20 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
             "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        },
+        "mute-stream": {
+            "version": "0.0.7",
+            "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
+            "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s="
+        },
+        "node-fetch": {
+            "version": "1.6.3",
+            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.6.3.tgz",
+            "integrity": "sha1-3CNO3WSJmC1Y6PDbT2lQKavNjAQ=",
+            "requires": {
+                "encoding": "0.1.12",
+                "is-stream": "1.1.0"
+            }
         },
         "normalize-package-data": {
             "version": "2.4.0",
@@ -1101,6 +1211,70 @@
                 "wrappy": "1.0.2"
             }
         },
+        "onetime": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
+            "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+            "requires": {
+                "mimic-fn": "1.2.0"
+            }
+        },
+        "opencollective": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/opencollective/-/opencollective-1.0.3.tgz",
+            "integrity": "sha1-ruY3K8KBRFg2kMPKja7PwSDdDvE=",
+            "requires": {
+                "babel-polyfill": "6.23.0",
+                "chalk": "1.1.3",
+                "inquirer": "3.0.6",
+                "minimist": "1.2.0",
+                "node-fetch": "1.6.3",
+                "opn": "4.0.2"
+            },
+            "dependencies": {
+                "ansi-styles": {
+                    "version": "2.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+                    "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+                },
+                "chalk": {
+                    "version": "1.1.3",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+                    "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+                    "requires": {
+                        "ansi-styles": "2.2.1",
+                        "escape-string-regexp": "1.0.5",
+                        "has-ansi": "2.0.0",
+                        "strip-ansi": "3.0.1",
+                        "supports-color": "2.0.0"
+                    }
+                },
+                "minimist": {
+                    "version": "1.2.0",
+                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+                    "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+                },
+                "supports-color": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+                    "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+                }
+            }
+        },
+        "opn": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/opn/-/opn-4.0.2.tgz",
+            "integrity": "sha1-erwi5kTf9jsKltWrfyeQwPAavJU=",
+            "requires": {
+                "object-assign": "4.1.1",
+                "pinkie-promise": "2.0.1"
+            }
+        },
+        "os-tmpdir": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+            "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
+        },
         "p-limit": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.2.0.tgz",
@@ -1144,14 +1318,6 @@
                 "is-dotfile": "1.0.3",
                 "is-extglob": "1.0.0",
                 "is-glob": "2.0.1"
-            }
-        },
-        "parse-json": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-3.0.0.tgz",
-            "integrity": "sha1-+m9HsY4jgm6tMvJj50TQ4ehH+xM=",
-            "requires": {
-                "error-ex": "1.3.1"
             }
         },
         "path-exists": {
@@ -1307,15 +1473,6 @@
                 "postcss": "6.0.16"
             }
         },
-        "postcss-sass": {
-            "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/postcss-sass/-/postcss-sass-0.2.0.tgz",
-            "integrity": "sha512-cUmYzkP747fPCQE6d+CH2l1L4VSyIlAzZsok3HPjb5Gzsq3jE+VjpAdGlPsnQ310WKWI42sw+ar0UNN59/f3hg==",
-            "requires": {
-                "gonzales-pe": "4.2.3",
-                "postcss": "6.0.16"
-            }
-        },
         "postcss-scss": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/postcss-scss/-/postcss-scss-1.0.3.tgz",
@@ -1442,6 +1599,11 @@
                 "strip-indent": "2.0.0"
             }
         },
+        "regenerator-runtime": {
+            "version": "0.10.5",
+            "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
+            "integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg="
+        },
         "regex-cache": {
             "version": "0.4.4",
             "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
@@ -1533,6 +1695,15 @@
             "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
             "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="
         },
+        "restore-cursor": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
+            "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+            "requires": {
+                "onetime": "2.0.1",
+                "signal-exit": "3.0.2"
+            }
+        },
         "rimraf": {
             "version": "2.6.2",
             "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
@@ -1540,6 +1711,19 @@
             "requires": {
                 "glob": "7.1.2"
             }
+        },
+        "run-async": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
+            "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
+            "requires": {
+                "is-promise": "2.1.0"
+            }
+        },
+        "rx": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/rx/-/rx-4.1.0.tgz",
+            "integrity": "sha1-pfE/957zt0D+MKqAP7CfmIBdR4I="
         },
         "safe-buffer": {
             "version": "5.1.1",
@@ -1674,14 +1858,14 @@
             "integrity": "sha1-eVjHk+R+MuB9K1yv5cC/jhLneQI="
         },
         "stylelint": {
-            "version": "8.4.0",
-            "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-8.4.0.tgz",
-            "integrity": "sha512-56hPH5mTFnk8LzlEuTWq0epa34fHuS54UFYQidBOFt563RJBNi1nz1F2HK2MoT1X1waq47milvRsRahFCCJs/Q==",
+            "version": "9.0.0",
+            "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-9.0.0.tgz",
+            "integrity": "sha512-SWQtdT3RBJSw+8xIltBrJfaYLIqFZgraHAhzbyKp/lyB+EpbqfD7txiEUeosVOH6SD1MOfhFWKgRrueymljFsg==",
             "requires": {
-                "autoprefixer": "7.2.5",
+                "autoprefixer": "8.0.0",
                 "balanced-match": "1.0.0",
                 "chalk": "2.3.0",
-                "cosmiconfig": "3.1.0",
+                "cosmiconfig": "4.0.0",
                 "debug": "3.1.0",
                 "execall": "1.0.0",
                 "file-entry-cache": "2.0.0",
@@ -1691,13 +1875,14 @@
                 "html-tags": "2.0.0",
                 "ignore": "3.3.7",
                 "imurmurhash": "0.1.4",
-                "known-css-properties": "0.5.0",
+                "known-css-properties": "0.6.1",
                 "lodash": "4.17.4",
                 "log-symbols": "2.2.0",
                 "mathml-tag-names": "2.0.1",
                 "meow": "4.0.0",
                 "micromatch": "2.3.11",
                 "normalize-selector": "0.2.0",
+                "opencollective": "1.0.3",
                 "pify": "3.0.0",
                 "postcss": "6.0.16",
                 "postcss-html": "0.12.0",
@@ -1706,7 +1891,7 @@
                 "postcss-reporter": "5.0.0",
                 "postcss-resolve-nested-selector": "0.1.1",
                 "postcss-safe-parser": "3.0.1",
-                "postcss-sass": "0.2.0",
+                "postcss-sass": "0.3.0",
                 "postcss-scss": "1.0.3",
                 "postcss-selector-parser": "3.1.1",
                 "postcss-value-parser": "3.3.0",
@@ -1717,6 +1902,109 @@
                 "sugarss": "1.0.1",
                 "svg-tags": "1.0.0",
                 "table": "4.0.2"
+            },
+            "dependencies": {
+                "autoprefixer": {
+                    "version": "8.0.0",
+                    "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-8.0.0.tgz",
+                    "integrity": "sha512-XBEqAoESCyGu3daYmWcTC37Dwmjvs0y40UtUO3MMX+Pd/w7jwNFfUKNtxoMFu0u0wcotP+arDpU3JVH54UV79Q==",
+                    "requires": {
+                        "browserslist": "3.1.1",
+                        "caniuse-lite": "1.0.30000809",
+                        "normalize-range": "0.1.2",
+                        "num2fraction": "1.2.2",
+                        "postcss": "6.0.19",
+                        "postcss-value-parser": "3.3.0"
+                    },
+                    "dependencies": {
+                        "chalk": {
+                            "version": "2.3.1",
+                            "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.1.tgz",
+                            "integrity": "sha512-QUU4ofkDoMIVO7hcx1iPTISs88wsO8jA92RQIm4JAwZvFGGAV2hSAA1NX7oVj2Ej2Q6NDTcRDjPTFrMCRZoJ6g==",
+                            "requires": {
+                                "ansi-styles": "3.2.0",
+                                "escape-string-regexp": "1.0.5",
+                                "supports-color": "5.2.0"
+                            }
+                        },
+                        "postcss": {
+                            "version": "6.0.19",
+                            "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.19.tgz",
+                            "integrity": "sha512-f13HRz0HtVwVaEuW6J6cOUCBLFtymhgyLPV7t4QEk2UD3twRI9IluDcQNdzQdBpiixkXj2OmzejhhTbSbDxNTg==",
+                            "requires": {
+                                "chalk": "2.3.1",
+                                "source-map": "0.6.1",
+                                "supports-color": "5.2.0"
+                            }
+                        }
+                    }
+                },
+                "browserslist": {
+                    "version": "3.1.1",
+                    "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-3.1.1.tgz",
+                    "integrity": "sha512-zHGaPnTt70ywm+glR7uMJFZSl+ADGO67SgD2ae20L+Y3KJUeH4fVa89OkTqKCqAnXFE9mO4LTHBKBqKRlr7VNw==",
+                    "requires": {
+                        "caniuse-lite": "1.0.30000809",
+                        "electron-to-chromium": "1.3.33"
+                    }
+                },
+                "caniuse-lite": {
+                    "version": "1.0.30000809",
+                    "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000809.tgz",
+                    "integrity": "sha512-tLn4flj2upmMsko3larTkQh21Vp9pylnNPUOhw5+mubL+67U5Fpm4UG5AutzGBc+gBIPSsPFHDynsiMWp5m46g=="
+                },
+                "cosmiconfig": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-4.0.0.tgz",
+                    "integrity": "sha512-6e5vDdrXZD+t5v0L8CrurPeybg4Fmf+FCSYxXKYVAqLUtyCSbuyqE059d0kDthTNRzKVjL7QMgNpEUlsoYH3iQ==",
+                    "requires": {
+                        "is-directory": "0.3.1",
+                        "js-yaml": "3.10.0",
+                        "parse-json": "4.0.0",
+                        "require-from-string": "2.0.1"
+                    }
+                },
+                "electron-to-chromium": {
+                    "version": "1.3.33",
+                    "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.33.tgz",
+                    "integrity": "sha1-vwBwPWKnxlI4E2V4w1LWxcBCpUU="
+                },
+                "has-flag": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+                    "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+                },
+                "known-css-properties": {
+                    "version": "0.6.1",
+                    "resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.6.1.tgz",
+                    "integrity": "sha512-nQRpMcHm1cQ6gmztdvLcIvxocznSMqH/y6XtERrWrHaymOYdDGroRqetJvJycxGEr1aakXiigDgn7JnzuXlk6A=="
+                },
+                "parse-json": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+                    "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+                    "requires": {
+                        "error-ex": "1.3.1",
+                        "json-parse-better-errors": "1.0.1"
+                    }
+                },
+                "postcss-sass": {
+                    "version": "0.3.0",
+                    "resolved": "https://registry.npmjs.org/postcss-sass/-/postcss-sass-0.3.0.tgz",
+                    "integrity": "sha512-nZJEFS2bT007CmzMjlZfZwcZKpSJ/JeFiVEdgrgvGZtAnORU+5BvN0cioNuDAVxwXHXp3hksCJzbZYPWkuw41Q==",
+                    "requires": {
+                        "gonzales-pe": "4.2.3",
+                        "postcss": "6.0.16"
+                    }
+                },
+                "supports-color": {
+                    "version": "5.2.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.2.0.tgz",
+                    "integrity": "sha512-F39vS48la4YvTZUPVeTqsjsFNrvcMwrV3RLZINsmHo+7djCvuUzSIeXOnZ5hmjef4bajL1dNccN+tg5XAliO5Q==",
+                    "requires": {
+                        "has-flag": "3.0.0"
+                    }
+                }
             }
         },
         "stylelint-order": {
@@ -1773,6 +2061,19 @@
                 "lodash": "4.17.4",
                 "slice-ansi": "1.0.0",
                 "string-width": "2.1.1"
+            }
+        },
+        "through": {
+            "version": "2.3.8",
+            "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+            "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
+        },
+        "tmp": {
+            "version": "0.0.33",
+            "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+            "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+            "requires": {
+                "os-tmpdir": "1.0.2"
             }
         },
         "trim": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
         "test": "stylelint 'tests/**/*.scss'"
     },
     "dependencies": {
-        "stylelint": "8.4.0",
+        "stylelint": "9.0.0",
         "stylelint-order": "0.8.0",
         "stylelint-scss": "2.3.0"
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@zattoo/stylelint-config",
-    "version": "2.0.2",
+    "version": "2.1.0",
     "main": ".stylelintrc",
     "license": "MIT",
     "description": "Extensible shared Zattoo's Stylelint config",

--- a/package.json
+++ b/package.json
@@ -35,11 +35,8 @@
         "test": "stylelint 'tests/**/*.scss'"
     },
     "dependencies": {
-        "stylelint": "9.0.0",
+        "stylelint": "9.1.1",
         "stylelint-order": "0.8.1",
         "stylelint-scss": "2.4.0"
-    },
-    "peerDependencies": {
-        "stylelint": "^8.4.0"
     }
 }

--- a/package.json
+++ b/package.json
@@ -35,11 +35,8 @@
         "test": "stylelint 'tests/**/*.scss'"
     },
     "dependencies": {
-        "stylelint": "8.4.0",
-        "stylelint-order": "0.8.0",
-        "stylelint-scss": "2.3.0"
-    },
-    "peerDependencies": {
-        "stylelint": "^8.4.0"
+        "stylelint": "9.1.1",
+        "stylelint-order": "0.8.1",
+        "stylelint-scss": "2.4.0"
     }
 }

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "dependencies": {
         "stylelint": "9.0.0",
         "stylelint-order": "0.8.1",
-        "stylelint-scss": "2.3.0"
+        "stylelint-scss": "2.4.0"
     },
     "peerDependencies": {
         "stylelint": "^8.4.0"

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     },
     "dependencies": {
         "stylelint": "9.0.0",
-        "stylelint-order": "0.8.0",
+        "stylelint-order": "0.8.1",
         "stylelint-scss": "2.3.0"
     },
     "peerDependencies": {


### PR DESCRIPTION
Appeared that stylelint can work from the box (node_modules). We don't need to peer it. This Release removes stylelint as peer and update other dependencies to latest versions.